### PR TITLE
Implement Runnable request without Promise

### DIFF
--- a/src/main/scala/com/github/matsluni/akkahttpspi/RunnableRequest.scala
+++ b/src/main/scala/com/github/matsluni/akkahttpspi/RunnableRequest.scala
@@ -40,7 +40,7 @@ class RunnableRequest(httpRequest: HttpRequest, handler: SdkAsyncHttpResponseHan
       .singleRequest(httpRequest)
       .flatMap { response =>
         val sdkResponse = SdkHttpFullResponse.builder()
-            .headers(response.headers.groupBy(_.name()).map{ case (k, v) => k -> v.map(_.value()).asJava }.asJava)
+            .headers(response.headers.groupBy(_.name()).mapValues(_.map(_.value()).asJava).asJava)
             .statusCode(response.status.intValue())
             .statusText(response.status.reason)
             .build

--- a/src/main/scala/com/github/matsluni/akkahttpspi/RunnableRequest.scala
+++ b/src/main/scala/com/github/matsluni/akkahttpspi/RunnableRequest.scala
@@ -40,7 +40,7 @@ class RunnableRequest(httpRequest: HttpRequest, handler: SdkAsyncHttpResponseHan
       .singleRequest(httpRequest)
       .flatMap { response =>
         val sdkResponse = SdkHttpFullResponse.builder()
-            .headers(response.headers.groupBy(_.name()).mapValues(_.map(_.value()).asJava).asJava)
+            .headers(response.headers.groupBy(_.name()).map{ case (k, v) => k -> v.map(_.value()).asJava }.asJava)
             .statusCode(response.status.intValue())
             .statusText(response.status.reason)
             .build


### PR DESCRIPTION
If `Http().singleRequest` was failing, the promise was never completed and the `handler` wasn't signaled with `onError`.

This lead to problems for some Alpakka users: See [#1665](https://github.com/akka/alpakka/issues/1665)