### PR TITLE
Added `withConnectionPoolSettings` to AkkaHttpClientBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ val eventualResponse = client.listBuckets()
 If you need to connect to some AWS service from internal Corporate, where is needed to configure a Proxy, it can be performed in the following way:
 
 ```scala
+val system = ActorSystem("aws-akka-http")
+
 val proxyHost = "localhost"
 val proxyPort = 8888
 
@@ -59,7 +61,7 @@ val settings = ConnectionPoolSettings(system)
 lazy val akkaHttpClient = 
   AkkaHttpClient
     .builder()
-    .withActorSystem(actorSystem)
+    .withActorSystem(system)
     .withConnectionPoolSettings(settings)
     .build()
     

--- a/README.md
+++ b/README.md
@@ -40,6 +40,35 @@ val client = S3AsyncClient
               .region(Region.EU_CENTRAL_1)
               .httpClient(akkaClient)
               .build()
+
+val eventualResponse = client.listBuckets()
+```
+
+If you need to connect to some AWS service from internal Corporate, where is needed to configure a Proxy, it can be performed in the following way:
+
+```scala
+val proxyHost = "localhost"
+val proxyPort = 8888
+
+val httpsProxyTransport = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved(proxyHost, proxyPort))
+
+val settings = ConnectionPoolSettings(system)
+  .withConnectionSettings(ClientConnectionSettings(system)
+  .withTransport(httpsProxyTransport))
+
+lazy val akkaHttpClient = 
+  AkkaHttpClient
+    .builder()
+    .withActorSystem(actorSystem)
+    .withConnectionPoolSettings(settings)
+    .build()
+    
+val client = S3AsyncClient
+	.builder()
+	.credentialsProvider(ProfileCredentialsProvider.builder().build())
+	.region(Region.EU_CENTRAL_1)
+	.httpClient(akkaHttpClient)
+	.build()
               
 val eventualResponse = client.listBuckets()
 ```


### PR DESCRIPTION
In this PR has been added a function `withConnectionPoolSettings` to the builder `AkkaHttpClientBuilder`, in order to support Connection settings like _Corporate Proxy_.

Following the example of @gabfssilva, the new builder method can be used this way:
```scala
val proxyHost = "localhost"
val proxyPort = 8888

val httpsProxyTransport = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved(proxyHost, proxyPort))

val settings = ConnectionPoolSettings(system)
  .withConnectionSettings(ClientConnectionSettings(system)
  .withTransport(httpsProxyTransport))

lazy val sdkAsyncHttpClient: SdkAsyncHttpClient = 
  AkkaHttpClient
    .builder()
    .withActorSystem(actorSystem)
    .withConnectionPoolSettings(settings)
    .build()
```

I preferred to call this method `withConnectionPoolSettings` since it is not only relative to proxy settings, but it supports other kind of options as described in [AkkaHTTP API docs](https://doc.akka.io/api/akka-http/10.1.9/akka/http/scaladsl/settings/ConnectionPoolSettings.html).

Since in the `README.md`, I read:
> the underlying SPI is subject to change.

I don't know if the builder's implementation way can change, or you have in mind another idea of how to implement a more rich builder, anyway I followed the already existing style.

On the other hand, the code hasn't a code format, if you agree I can add `scalafmt` 😊

Thanks in advance, I open to get feedbacks and hints regarding PR.
Best regards.

Fernando.
