### PR TITLE
Avoid calling LoggerFactory.getLogger each request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.8
-  - 2.13.0
+  - 2.12.10
+  - 2.13.1
 
 services:
   - docker

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ lazy val commonSettings = Seq(
     "-encoding", "UTF-8",
     "-unchecked",
     "-deprecation"),
-  scalaVersion := "2.12.9",
+  scalaVersion := "2.12.10",
   description := "An alternative non-blocking async http engine for aws-sdk-java-v2 based on akka-http",
-  crossScalaVersions := Seq("2.11.12", "2.12.9", "2.13.0"),
+  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
   organization := "com.github.matsluni",
   name := "aws-spi-akka-http",
   licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
@@ -50,9 +50,9 @@ lazy val root = (project in file("."))
 
 
 lazy val deps = {
-  val awsSDKVersion = "2.5.60"
+  val awsSDKVersion = "2.9.19"
   val akkaVersion = "2.5.25"
-  val AkkaHttpVersion = "10.1.9"
+  val AkkaHttpVersion = "10.1.10"
 
   Seq(
     "com.typesafe.akka"       %% "akka-stream"          % akkaVersion     withSources(),

--- a/src/main/scala/com/github/matsluni/akkahttpspi/AkkaHttpClient.scala
+++ b/src/main/scala/com/github/matsluni/akkahttpspi/AkkaHttpClient.scala
@@ -43,9 +43,11 @@ import scala.concurrent.{Await, ExecutionContext}
 class AkkaHttpClient(shutdownHandle: () => Unit, connectionSettings: ConnectionPoolSettings)(implicit actorSystem: ActorSystem, ec: ExecutionContext, mat: Materializer) extends SdkAsyncHttpClient {
   import AkkaHttpClient._
 
+  lazy val runner = new RequestRunner(connectionSettings)
+
   override def execute(request: AsyncExecuteRequest): CompletableFuture[Void] = {
     val akkaHttpRequest = toAkkaRequest(request.request(), request.requestContentPublisher())
-    new RunnableRequest(akkaHttpRequest, connectionSettings, request.responseHandler()).run()
+    runner.run(akkaHttpRequest, request.responseHandler())
   }
 
   override def close(): Unit = {


### PR DESCRIPTION
I'm pretty sure the logger is cached inside LoggerFactory, but, it also does lots of things that isn't needed each request, so, changing `RunnableRequest` to `RequestRunner` and creating only one instance of it.