### PR TITLE
Remove duplicate dependency entry in published pom file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,10 +55,10 @@ lazy val deps = {
   val AkkaHttpVersion = "10.1.13"
 
   Seq(
-    "com.typesafe.akka"       %% "akka-stream"             % akkaVersion     withSources(),
-    "com.typesafe.akka"       %% "akka-http"               % AkkaHttpVersion withSources(),
-    "software.amazon.awssdk"  %  "http-client-spi"         % awsSDKVersion   withSources(),
-    "org.scala-lang.modules"  %% "scala-collection-compat" % "2.3.1"         withSources(),
+    "com.typesafe.akka"       %% "akka-stream"             % akkaVersion,
+    "com.typesafe.akka"       %% "akka-http"               % AkkaHttpVersion,
+    "software.amazon.awssdk"  %  "http-client-spi"         % awsSDKVersion,
+    "org.scala-lang.modules"  %% "scala-collection-compat" % "2.3.1",
 
     "software.amazon.awssdk"  %  "s3"                      % awsSDKVersion   % "test" exclude("software.amazon.awssdk", "netty-nio-client"),
     "software.amazon.awssdk"  %  "dynamodb"                % awsSDKVersion   % "test" exclude("software.amazon.awssdk", "netty-nio-client"),


### PR DESCRIPTION
You can see in https://mvnrepository.com/artifact/com.github.matsluni/aws-spi-akka-http_2.13/0.0.11 some dependencies are duplicated 

![image](https://user-images.githubusercontent.com/943051/104036303-27085300-51cb-11eb-9bab-d8b0d2860bfd.png)

PS: Thanks for this nice library