### PR TITLE
Allow using SdkHttpConfigurationOption over default akka-http connection settings

### DIFF
--- a/src/test/scala/com/github/matsluni/akkahttpspi/AkkaHttpClientSpec.scala
+++ b/src/test/scala/com/github/matsluni/akkahttpspi/AkkaHttpClientSpec.scala
@@ -112,6 +112,23 @@ class AkkaHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
 
       akkaClient.connectionSettings shouldBe connectionPoolSettings
     }
+
+    "withConnectionPoolSettings().build() should use passed ConnectionPoolSettings" in {
+      val connectionPoolSettings = ConnectionPoolSettings(ConfigFactory.load())
+        .withConnectionSettings(
+          ClientConnectionSettings(ConfigFactory.load())
+            .withConnectingTimeout(1.second)
+            .withIdleTimeout(2.seconds)
+        )
+        .withMaxConnections(3)
+        .withMaxConnectionLifetime(4.seconds)
+      val akkaClient: AkkaHttpClient = new AkkaHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .withConnectionPoolSettings(connectionPoolSettings)
+        .build()
+        .asInstanceOf[AkkaHttpClient]
+
+      akkaClient.connectionSettings shouldBe connectionPoolSettings
+    }
   }
 
   private def infiniteToZero(duration: scala.concurrent.duration.Duration): java.time.Duration = duration match {

--- a/src/test/scala/com/github/matsluni/akkahttpspi/AkkaHttpClientSpec.scala
+++ b/src/test/scala/com/github/matsluni/akkahttpspi/AkkaHttpClientSpec.scala
@@ -18,11 +18,17 @@ package com.github.matsluni.akkahttpspi
 
 import akka.http.scaladsl.model.headers.`Content-Type`
 import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
+import com.typesafe.config.ConfigFactory
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import software.amazon.awssdk.http.SdkHttpConfigurationOption
+import software.amazon.awssdk.utils.AttributeMap
 
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
 
 class AkkaHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
 
@@ -46,5 +52,70 @@ class AkkaHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
       contentTypeHeader.value.lowercaseName() shouldBe `Content-Type`.lowercaseName
       reqHeaders should have size 1
     }
+
+    "build() should use default ConnectionPoolSettings" in {
+      val akkaClient: AkkaHttpClient = new AkkaHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .build()
+        .asInstanceOf[AkkaHttpClient]
+
+      akkaClient.connectionSettings shouldBe ConnectionPoolSettings(ConfigFactory.load())
+    }
+
+    "withConnectionPoolSettingsBuilderFromAttributeMap().buildWithDefaults() should propagate configuration options" in {
+      val attributeMap = AttributeMap.builder()
+        .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, 1.second.toJava)
+        .put(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT, 2.second.toJava)
+        .put(SdkHttpConfigurationOption.MAX_CONNECTIONS, 3)
+        .put(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE, 4.second.toJava)
+        .build()
+      val akkaClient: AkkaHttpClient = new AkkaHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .withConnectionPoolSettingsBuilderFromAttributeMap()
+        .buildWithDefaults(attributeMap)
+        .asInstanceOf[AkkaHttpClient]
+
+      akkaClient.connectionSettings.connectionSettings.connectingTimeout shouldBe 1.second
+      akkaClient.connectionSettings.connectionSettings.idleTimeout shouldBe 2.seconds
+      akkaClient.connectionSettings.maxConnections shouldBe 3
+      akkaClient.connectionSettings.maxConnectionLifetime shouldBe 4.seconds
+    }
+
+    "withConnectionPoolSettingsBuilderFromAttributeMap().build() should fallback to GLOBAL_HTTP_DEFAULTS" in {
+      val akkaClient: AkkaHttpClient = new AkkaHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .withConnectionPoolSettingsBuilderFromAttributeMap()
+        .build()
+        .asInstanceOf[AkkaHttpClient]
+
+      akkaClient.connectionSettings.connectionSettings.connectingTimeout shouldBe
+        SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toScala
+      akkaClient.connectionSettings.connectionSettings.idleTimeout shouldBe
+        SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT).toScala
+      akkaClient.connectionSettings.maxConnections shouldBe
+        SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.MAX_CONNECTIONS).intValue()
+      infiniteToZero(akkaClient.connectionSettings.maxConnectionLifetime) shouldBe
+        SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE)
+    }
+
+    "withConnectionPoolSettingsBuilder().build() should use passed connectionPoolSettings builder" in {
+      val connectionPoolSettings = ConnectionPoolSettings(ConfigFactory.load())
+        .withConnectionSettings(
+          ClientConnectionSettings(ConfigFactory.load())
+            .withConnectingTimeout(1.second)
+            .withIdleTimeout(2.seconds)
+        )
+        .withMaxConnections(3)
+        .withMaxConnectionLifetime(4.seconds)
+
+      val akkaClient: AkkaHttpClient = new AkkaHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .withConnectionPoolSettingsBuilder((_, _) => connectionPoolSettings)
+        .build()
+        .asInstanceOf[AkkaHttpClient]
+
+      akkaClient.connectionSettings shouldBe connectionPoolSettings
+    }
+  }
+
+  private def infiniteToZero(duration: scala.concurrent.duration.Duration): java.time.Duration = duration match {
+    case _: scala.concurrent.duration.Duration.Infinite => java.time.Duration.ZERO
+    case duration: FiniteDuration => duration.toJava
   }
 }

--- a/src/test/scala/com/github/matsluni/akkahttpspi/BaseAwsClientTest.scala
+++ b/src/test/scala/com/github/matsluni/akkahttpspi/BaseAwsClientTest.scala
@@ -53,7 +53,7 @@ trait LocalstackBaseAwsClientTest[C <: SdkClient] extends BaseAwsClientTest[C] {
   lazy val exposedServicePort: Int = 4566
 
   private lazy val containerInstance = new GenericContainer(
-    dockerImage = "localstack/localstack",
+    dockerImage = "localstack/localstack:1.4.0",
     exposedPorts = Seq(exposedServicePort),
     env = Map("SERVICES" -> service),
     waitStrategy = Some(LocalStackReadyLogWaitStrategy)


### PR DESCRIPTION
introduce `withConnectionPoolSettingsBuilder` and `withConnectionPoolSettingsBuilderFromAttributeMap` to allow the usage of AWS SDK configuration options

This change is introduced in a backwards compatible change. To use the new functionality `withConnectionPoolSettingsBuilderFromAttributeMap` should be used. Check the unit tests for examples

Fixes #232